### PR TITLE
removed duplicate bean definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.3'
+version '0.0.4'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/uk/gov/hmcts/reform/health/Liveness.java
+++ b/src/main/java/uk/gov/hmcts/reform/health/Liveness.java
@@ -2,9 +2,7 @@ package uk.gov.hmcts.reform.health;
 
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.stereotype.Component;
 
-@Component
 public class Liveness extends AbstractHealthIndicator {
 
     @Override


### PR DESCRIPTION
### Change description ###
Liveness bean is  already defined in HealthAutoConfiguration.java. So, @Component is a redundant one - this forces clients to set spring.main.allow-bean-definition-overriding=true explicitly. 
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.1-Release-Notes#bean-overriding   

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```
